### PR TITLE
fix(alias): Fix output name conflict

### DIFF
--- a/pollination/direct_sun_hours/entry.py
+++ b/pollination/direct_sun_hours/entry.py
@@ -137,12 +137,6 @@ class DirectSunHoursEntryPoint(DAG):
     ):
         pass
 
-    results = Outputs.folder(
-        source='results',
-        description='Results folder. There are 3 subfolders under results folder: '
-        'direct_sun_hours, cumulative and direct_radiation.'
-    )
-
     direct_sun_hours = Outputs.folder(
         source='results/direct_sun_hours',
         description='Hourly results for direct sun hours.',


### PR DESCRIPTION
I think it's easier to just remove the results output as it's redundant.  We already output all of the subfolders within this folder and it's really only creating unwanted name conflicts at this point.