### PR TITLE
fix(recipe): Fix a couple of bugs in the recipe

### DIFF
--- a/pollination/direct_sun_hours/_direct_sunlight_calc.py
+++ b/pollination/direct_sun_hours/_direct_sunlight_calc.py
@@ -57,7 +57,7 @@ class DirectSunHoursCalculation(DAG):
     )
     def convert_to_sun_hours(
         self, input_mtx=direct_radiation_calculation._outputs.result_file,
-        grid_name=grid_name
+        grid_name=grid_name, minimum=0, include_min='exclude'
     ):
         return [
             {

--- a/pollination/direct_sun_hours/_raytracing.py
+++ b/pollination/direct_sun_hours/_raytracing.py
@@ -63,23 +63,6 @@ class DirectSunHoursEntryLoop(DAG):
     @task(
         template=MergeFiles, needs=[direct_sunlight]
     )
-    def merge_radiation_results(
-        self, name=grid_name, extension='.ill', folder='direct-radiation'
-            ):
-        """Merge results from several grids into a single file.
-
-        These values are irradiance values.
-        """
-        return [
-            {
-                'from': MergeFiles()._outputs.result_file,
-                'to': '../../results/direct_radiation/{{self.name}}.ill'
-            }
-        ]
-
-    @task(
-        template=MergeFiles, needs=[direct_sunlight]
-    )
     def merge_direct_sun_hours(
         self, name=grid_name, extension='.ill', folder='direct-sun-hours'
             ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pollination-honeybee-radiance>=0.7.1
+pollination-ladybug>=0.2.1
 pollination-alias>=0.5.3
 pollination-path>=0.1.3


### PR DESCRIPTION
The recipe now computes direct sun hours regardless of whether the input wea has direct irradiance for a certain hour. This also fixes a bug that results from the fact that the defaults of the ConvertToBinary function changed.

Lastly, it removes the direct radiation output since it no longer has any meaning when all of the Wea values are the same.

CC: @mostaphaRoudsari 