### PR TITLE
fix(result): Remove unused/incorrect direct radiation result

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,12 @@
 # direct-sun-hours
 
-Direct sun hours for Pollination
+Direct sun hours recipe.
 
-Calculate the number of hours of direct sunlight received by grids of sensors during the
-year. The recipe generates 3 subfolders under results folder:
+Calculate the number of hours of direct sunlight received by grids of sensors during
+the time period of a specified Wea. The recipe generates 2 sub-folders of results:
 
-1. `direct_sun_hours`: Hourly results for number of hours that each sensor is exposed
-  to sun. The units are the timestep of input wea file. For an hourly wea each value
-  corresponds to an hour of direct sunlight.
+1. `direct_sun_hours`: A matrix of zero/one valued indicating whether each sensor
+  is exposed to the sun at a given time step of the input Wea.
 
-2. `cumulative`: The cumulative number of hours for each sensor during all the timesteps.
-  The value is a single integer for each input sensor.
-
-3. `direct_radiation`: Hourly direct radiation from sun. This output does not include the
-  indirect sky radiation. For total radiation see `annual radiation` or
-`annual sky radiation` recipes.
-
-# Limitations
-
-This recipe is limited to calculating up to `9999` number of suns at a time. This means
-you might need to break down the annual studies with smaller timesteps into smaller
-runs. This limitation is a result of how Radiance sets a limit on number of modifiers
-in a single run. [See here](https://discourse.radiance-online.org/t/increase-maximum-number-of-modifiers-in-rcontrib/4684). We can address this limitation by either building our own version of Radiance
-or breaking down the modifier list and looping over them and merging back the results.
+2. `cumulative`: The cumulative number of Wea time steps that each sensor can see the
+  sun. Each value is a single integer for each input sensor.

--- a/pollination/direct_sun_hours/_direct_sunlight_calc.py
+++ b/pollination/direct_sun_hours/_direct_sunlight_calc.py
@@ -38,8 +38,8 @@ class DirectSunHoursCalculation(DAG):
         optional=True
     )
 
-    @task(template=DaylightContribution, sub_folder='direct-radiation')
-    def direct_radiation_calculation(
+    @task(template=DaylightContribution, sub_folder='direct-irradiance')
+    def direct_irradiance_calculation(
         self,
         fixed_radiance_parameters='-aa 0.0 -I -faa -ab 0 -dc 1.0 -dt 0.0 -dj 0.0 -dr 0',
         conversion='0.265 0.670 0.065',
@@ -58,11 +58,11 @@ class DirectSunHoursCalculation(DAG):
         ]
 
     @task(
-        template=ConvertToBinary, needs=[direct_radiation_calculation],
+        template=ConvertToBinary, needs=[direct_irradiance_calculation],
         sub_folder='direct-sun-hours'
     )
     def convert_to_sun_hours(
-        self, input_mtx=direct_radiation_calculation._outputs.result_file,
+        self, input_mtx=direct_irradiance_calculation._outputs.result_file,
         grid_name=grid_name, minimum=0, include_min='exclude'
     ):
         return [

--- a/pollination/direct_sun_hours/entry.py
+++ b/pollination/direct_sun_hours/entry.py
@@ -4,7 +4,7 @@ from pollination.ladybug.translate import WeaToConstant
 from pollination.honeybee_radiance.sun import CreateSunMatrix, ParseSunUpHours
 from pollination.honeybee_radiance.translate import CreateRadianceFolderGrid
 from pollination.honeybee_radiance.octree import CreateOctreeWithSky
-from pollination.path.copy import CopyMultiple
+from pollination.path.copy import Copy
 
 # input/output alias
 from pollination.alias.inputs.model import hbjson_model_input
@@ -103,16 +103,12 @@ class DirectSunHoursEntryPoint(DAG):
             }
         ]
 
-    @task(template=CopyMultiple, needs=[create_rad_folder])
+    @task(template=Copy, needs=[create_rad_folder])
     def copy_grid_info(self, src=create_rad_folder._outputs.sensor_grids_file):
         return [
             {
-                'from': CopyMultiple()._outputs.dst_1,
+                'from': Copy()._outputs.dst,
                 'to': 'results/cumulative/grids_info.json'
-            },
-            {
-                'from': CopyMultiple()._outputs.dst_2,
-                'to': 'results/direct_radiation/grids_info.json'
             }
         ]
 


### PR DESCRIPTION
I realized that we were still copying the grids_info.json into a radiation result folder even though we were no longer reporting such radiation results (they are inaccurate given the way that we change the Wea values to be all the same.

Also, we still had a disclaimer about the radiance modifier limitations in the Readme, which is no longer relevant.